### PR TITLE
feature: add the materialization to the description box

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -285,6 +285,17 @@ function Graph3D({
                     </Button>
                   </HStack>
 
+                    {/* Add Materialization Info */}
+                  <VStack spacing={0} alignItems="baseline" my={2}>
+                    <Text fontSize='sm' fontWeight="bold" textTransform="uppercase" opacity={0.6}>
+                      Materialization
+                    </Text>
+                    <Text>
+                      {cur_node_details.config?.materialized || "Not specified"}
+                    </Text>
+                  </VStack>
+                  <Divider my={2} />
+
                   <VStack spacing={0} alignItems="baseline" my={2}>
                     <Text fontSize='sm' fontWeight="bold" textTransform="uppercase" opacity={0.6}>
                       Description


### PR DESCRIPTION
# 📓 Description
This PR adds the functionality to view the materialisation of a model  when clicking the node.
<img width="801" alt="Screenshot 2024-10-01 at 17 31 14" src="https://github.com/user-attachments/assets/073d2351-4cab-485e-a234-926ee23d4e52">

# 🙋‍♂️ How to test?
- checkout to this branch
- run `npm install`
- run `npm run dev`
- click on any node
- you should see a `MATERIALIZATION` section in the info window with the correct materialisation for that model 